### PR TITLE
Update eslint-config-prettier to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@typescript-eslint/parser": "^4.6.0",
     "cpx": "^1.5.0",
     "eslint": "^7.12.1",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "gas-webpack-plugin": "^1.0.2",
     "jest": "^26.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,12 +1796,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.10.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
-  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
-  dependencies:
-    get-stdin "^6.0.0"
+eslint-config-prettier@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
+  integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
 
 eslint-plugin-prettier@^3.1.2:
   version "3.1.4"
@@ -2265,11 +2263,6 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
## Version **7.0.0** of **eslint-config-prettier** was just published.

* Package: [repository](https://github.com/prettier/eslint-config-prettier.git), [npm](https://www.npmjs.com/package/eslint-config-prettier)
* Current Version: 6.15.0
* Dev: true
* [compare 6.15.0 to 7.0.0 diffs](https://github.com/prettier/eslint-config-prettier/compare/v6.15.0...v7.0.0)

The version(`7.0.0`) is **not covered** by your current version range(`^6.10.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: