### PR TITLE
Update @types/node to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@types/google-apps-script": "^1.0.10",
     "@types/jest": "^26.0.15",
-    "@types/node": "^14.14.5",
+    "@types/node": "^15.0.0",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "cpx": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,10 +613,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/node@*", "@types/node@^14.14.5":
+"@types/node@*":
   version "14.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
   integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
+
+"@types/node@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.0.tgz#557dd0da4a6dca1407481df3bbacae0cd6f68042"
+  integrity sha512-YN1d+ae2MCb4U0mMa+Zlb5lWTdpFShbAj5nmte6lel27waMMBfivrm0prC16p/Di3DyTrmerrYUT8/145HXxVw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
## Version **15.0.0** of **@types/node** was just published.

* Package: [repository](https://github.com/DefinitelyTyped/DefinitelyTyped.git), [npm](https://www.npmjs.com/package/@types/node)
* Current Version: 14.14.6
* Dev: true


The version(`15.0.0`) is **not covered** by your current version range(`^14.14.5`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: